### PR TITLE
fix: change named import in file kelvin.js

### DIFF
--- a/src/lib/kelvin.js
+++ b/src/lib/kelvin.js
@@ -1,6 +1,6 @@
 import { kelvinToCelcius } from "./kelvin-to-celcius.js"
 import { kelvinReamur as kelvinToReamur } from "./kelvin-to-reamur.js"
-import { kelvinToFahrenheit } from "./kelvin-to-fahrenhei.js"
+import { kelvinToFahrenheit } from "./kelvin-to-fahrenheit.js"
 
 export {kelvinToCelcius, kelvinToReamur, kelvinToFahrenheit}
 

--- a/src/lib/kelvin.js
+++ b/src/lib/kelvin.js
@@ -1,6 +1,6 @@
 import { kelvinToCelcius } from "./kelvin-to-celcius.js"
 import { kelvinReamur as kelvinToReamur } from "./kelvin-to-reamur.js"
-import { kelvinToFahrenheit } from "./kelvin-to-fahrenhei.jst"
+import { kelvinToFahrenheit } from "./kelvin-to-fahrenhei.js"
 
 export {kelvinToCelcius, kelvinToReamur, kelvinToFahrenheit}
 

--- a/src/lib/kelvin.js
+++ b/src/lib/kelvin.js
@@ -1,6 +1,6 @@
-import { kelvinToCelcius } from "./kelvin-to-celcius"
-import { kelvinReamur as kelvinToReamur } from "./kelvin-to-reamur"
-import { kelvinToFahrenheit } from "./kelvin-to-fahrenheit"
+import { kelvinToCelcius } from "./kelvin-to-celcius.js"
+import { kelvinReamur as kelvinToReamur } from "./kelvin-to-reamur.js"
+import { kelvinToFahrenheit } from "./kelvin-to-fahrenhei.jst"
 
 export {kelvinToCelcius, kelvinToReamur, kelvinToFahrenheit}
 


### PR DESCRIPTION
Adds missing .js file extensions to kelvin related import statements #85
